### PR TITLE
Google Login (Expo Client Only)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -5,6 +5,7 @@ module.exports = function (api) {
     plugins: [
       ['module-resolver', {
         'alias': {
+          '@auth': './modules/auth',
           '@core': './modules/core',
           '@navigation': './modules/navigation/',
           '@home': './modules/home',

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      "@auth/*": ["modules/auth/*"],
       "@core/*": ["modules/core/*"],
       "@home/*": ["modules/home/*"],
       "@navigation/*": ["modules/navigation/*"],

--- a/modules/auth/src/google-auth.js
+++ b/modules/auth/src/google-auth.js
@@ -1,4 +1,5 @@
 import { Google } from 'expo';
+import { deleteItemAsync, getItemAsync, setItemAsync } from 'expo-secure-store';
 
 const config = {
   iosClientId: '187519984491-61hv6hvufpeiai7sg41rre5ka62e5fs7.apps.googleusercontent.com',
@@ -12,8 +13,9 @@ export async function SignInWithGoogleAsync() {
   try {
     const { type, accessToken } = await Google.logInAsync(config);
     if (type === 'success') {
+      await setItemAsync('google-access-token', accessToken);
       return {
-        accessToken,
+        success: true,
       };
     } else {
       return {
@@ -27,12 +29,14 @@ export async function SignInWithGoogleAsync() {
   }
 }
 
-export async function SignOutWithGoogleAsync({ accessToken }) {
+export async function SignOutWithGoogleAsync() {
+  const accessToken = await getItemAsync('google-access-token');
   try {
     await Google.logOutAsync({
       accessToken,
       ...config,
     });
+    await deleteItemAsync('google-access-token');
   } catch (e) {
     return {
       error: true,

--- a/modules/auth/src/google-auth.js
+++ b/modules/auth/src/google-auth.js
@@ -1,0 +1,41 @@
+import { Google } from 'expo';
+
+const config = {
+  iosClientId: '187519984491-61hv6hvufpeiai7sg41rre5ka62e5fs7.apps.googleusercontent.com',
+  androidClientId: '187519984491-jlj13hshd2alq5krd1ql08gh87lq0eq2.apps.googleusercontent.com',
+  // iosStandaloneAppClientId: '<YOUR_IOS_CLIENT_ID>',
+  // androidStandaloneAppClientId: '<YOUR_ANDROID_CLIENT_ID>',
+  scopes: ['profile'],
+};
+
+export async function SignInWithGoogleAsync() {
+  try {
+    const { type, accessToken } = await Google.logInAsync(config);
+    if (type === 'success') {
+      return {
+        accessToken,
+      };
+    } else {
+      return {
+        cancelled: true,
+      };
+    }
+  } catch (e) {
+    return {
+      error: true,
+    };
+  }
+}
+
+export async function SignOutWithGoogleAsync({ accessToken }) {
+  try {
+    await Google.logOutAsync({
+      accessToken,
+      ...config,
+    });
+  } catch (e) {
+    return {
+      error: true,
+    };
+  }
+}

--- a/modules/auth/test/google-auth-test.js
+++ b/modules/auth/test/google-auth-test.js
@@ -1,0 +1,22 @@
+import { SignInWithGoogleAsync } from '@auth/src/google-auth';
+
+jest.mock('expo', () => ({
+  Google: {
+    logInAsync: () => Promise.resolve({
+      type: 'success',
+      accessToken: 'some_access_token',
+    }),
+  },
+}));
+
+describe('GoogleAuth', () => {
+  describe('SignInWithGoogleAsync', () => {
+    describe('the login is successful', () => {
+      it('returns an accessToken', async () => {
+        const result = await SignInWithGoogleAsync();
+        console.log(result);
+        expect(result.accessToken).toEqual('some_access_token');
+      });
+    });
+  });
+});

--- a/modules/auth/test/google-auth-test.js
+++ b/modules/auth/test/google-auth-test.js
@@ -1,4 +1,5 @@
-import { SignInWithGoogleAsync } from '@auth/src/google-auth';
+import { SignInWithGoogleAsync, SignOutWithGoogleAsync } from '@auth/src/google-auth';
+import { deleteItemAsync, setItemAsync } from 'expo-secure-store';
 
 jest.mock('expo', () => ({
   Google: {
@@ -6,17 +7,31 @@ jest.mock('expo', () => ({
       type: 'success',
       accessToken: 'some_access_token',
     }),
+    logOutAsync: () => Promise.resolve({}),
   },
+}));
+
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+  getItemAsync: () => Promise.resolve('stored_access_token'),
 }));
 
 describe('GoogleAuth', () => {
   describe('SignInWithGoogleAsync', () => {
     describe('the login is successful', () => {
-      it('returns an accessToken', async () => {
-        const result = await SignInWithGoogleAsync();
-        console.log(result);
-        expect(result.accessToken).toEqual('some_access_token');
+      it('sets the access token in the secure store', async () => {
+        await SignInWithGoogleAsync();
+        expect(setItemAsync).toHaveBeenCalledWith('google-access-token', 'some_access_token');
       });
+    });
+  });
+
+  describe('SignOutWithGoogleAsync', () => {
+    it('deletes the access token in the secure store', async () => {
+      await SignInWithGoogleAsync();
+      await SignOutWithGoogleAsync();
+      expect(deleteItemAsync).toHaveBeenCalledWith('google-access-token');
     });
   });
 });

--- a/modules/home/src/scenes/home-screen.js
+++ b/modules/home/src/scenes/home-screen.js
@@ -1,20 +1,45 @@
 import Colors from '@theme/src/utils/colors';
-import React from 'react';
+import React, { useState } from 'react';
 import RehearseButton from '@core/src/components/rehearse-button';
 import RehearseText from '@core/src/components/rehearse-text';
 import Theme from '@theme/src/utils/theme';
 import { SafeAreaView, StyleSheet, View } from 'react-native';
+import { SignInWithGoogleAsync, SignOutWithGoogleAsync } from '@auth/src/google-auth';
 
 export default function HomeScreen() {
+  const [accessToken, setAccessToken] = useState();
+
+  const handleSignIn = async () => {
+    const result = await SignInWithGoogleAsync();
+    if (result.accessToken) { setAccessToken(result.accessToken); }
+  };
+
+  const handleSignOut = () => {
+    SignOutWithGoogleAsync(accessToken);
+    setAccessToken(undefined);
+  };
+
   return (
     <SafeAreaView style={styles.sceneContainer}>
       <View style={styles.appNameContainer}>
         <RehearseText style={styles.appName}>rehearse.</RehearseText>
       </View>
       <View style={styles.buttonContainer}>
-        <RehearseButton style={styles.button}>
-          <RehearseText>Continue</RehearseText>
-        </RehearseButton>
+        {accessToken ? (
+          <RehearseButton
+            onPress={handleSignOut}
+            style={styles.button}
+          >
+            <RehearseText>Sign Out</RehearseText>
+          </RehearseButton>
+        ) : (
+          <RehearseButton
+            onPress={handleSignIn}
+            style={styles.button}
+          >
+            <RehearseText>Sign In With Google</RehearseText>
+          </RehearseButton>
+        )}
       </View>
     </SafeAreaView>
   );

--- a/modules/home/src/scenes/home-screen.js
+++ b/modules/home/src/scenes/home-screen.js
@@ -1,22 +1,33 @@
 import Colors from '@theme/src/utils/colors';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import RehearseButton from '@core/src/components/rehearse-button';
 import RehearseText from '@core/src/components/rehearse-text';
 import Theme from '@theme/src/utils/theme';
 import { SafeAreaView, StyleSheet, View } from 'react-native';
 import { SignInWithGoogleAsync, SignOutWithGoogleAsync } from '@auth/src/google-auth';
+import { getItemAsync } from 'expo-secure-store';
 
 export default function HomeScreen() {
-  const [accessToken, setAccessToken] = useState();
+  const [isSignedIn, setIsSignedIn] = useState();
+
+  useEffect(() => {
+    const fetchAccessToken = async () => {
+      const accessToken = await getItemAsync('google-access-token');
+      setIsSignedIn(!!accessToken);
+    };
+    fetchAccessToken();
+  }, []);
 
   const handleSignIn = async () => {
-    const result = await SignInWithGoogleAsync();
-    if (result.accessToken) { setAccessToken(result.accessToken); }
+    await SignInWithGoogleAsync();
+    const accessToken = await getItemAsync('google-access-token');
+    setIsSignedIn(!!accessToken);
   };
 
-  const handleSignOut = () => {
-    SignOutWithGoogleAsync(accessToken);
-    setAccessToken(undefined);
+  const handleSignOut = async () => {
+    await SignOutWithGoogleAsync();
+    const accessToken = await getItemAsync('google-access-token');
+    setIsSignedIn(!!accessToken);
   };
 
   return (
@@ -25,7 +36,7 @@ export default function HomeScreen() {
         <RehearseText style={styles.appName}>rehearse.</RehearseText>
       </View>
       <View style={styles.buttonContainer}>
-        {accessToken ? (
+        {isSignedIn ? (
           <RehearseButton
             onPress={handleSignOut}
             style={styles.button}

--- a/modules/home/test/scenes/home-screen-test.js
+++ b/modules/home/test/scenes/home-screen-test.js
@@ -1,6 +1,13 @@
 import HomeScreen from '@home/src/scenes/home-screen';
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { act, fireEvent, render, wait } from '@testing-library/react-native';
+
+jest.mock('@auth/src/google-auth', () => ({
+  SignInWithGoogleAsync: () => Promise.resolve({
+    accessToken: 'some_access_token',
+  }),
+  SignOutWithGoogleAsync: () => Promise.resolve({}),
+}));
 
 describe('Homescreen', () => {
   it('should render the title of the app', () => {
@@ -8,8 +15,17 @@ describe('Homescreen', () => {
     getByText('rehearse.');
   });
 
-  it('contain a call to action to move forward in the app', () => {
-    const { getByText } = render(<HomeScreen />);
-    getByText('Continue');
+  describe('when the google login button is clicked and the login succeeds', () => {
+    it('calls the sign in with google method', async () => {
+      jest.useFakeTimers();
+      const { getByText } = render(<HomeScreen />);
+
+      fireEvent.press(getByText('Sign In With Google'));
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      await wait(() => getByText('Sign Out'));
+    });
   });
 });

--- a/modules/home/test/scenes/home-screen-test.js
+++ b/modules/home/test/scenes/home-screen-test.js
@@ -1,31 +1,55 @@
 import HomeScreen from '@home/src/scenes/home-screen';
 import React from 'react';
+import { SignInWithGoogleAsync } from '@auth/src/google-auth';
 import { act, fireEvent, render, wait } from '@testing-library/react-native';
 
 jest.mock('@auth/src/google-auth', () => ({
-  SignInWithGoogleAsync: () => Promise.resolve({
-    accessToken: 'some_access_token',
-  }),
-  SignOutWithGoogleAsync: () => Promise.resolve({}),
+  SignInWithGoogleAsync: jest.fn(),
+}));
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: () => {
+    return Promise.resolve(null);
+  },
 }));
 
 describe('Homescreen', () => {
-  it('should render the title of the app', () => {
+  it('renders the title of the app', () => {
+    jest.useFakeTimers();
     const { getByText } = render(<HomeScreen />);
+    act(() => {
+      jest.runAllTimers();
+    });
     getByText('rehearse.');
   });
 
-  describe('when the google login button is clicked and the login succeeds', () => {
-    it('calls the sign in with google method', async () => {
+  describe('when the user is signed out', () => {
+    it('renders the sign in button', async () => {
       jest.useFakeTimers();
       const { getByText } = render(<HomeScreen />);
-
-      fireEvent.press(getByText('Sign In With Google'));
       act(() => {
         jest.runAllTimers();
       });
+      await wait(() => getByText('Sign In With Google'));
+    });
 
-      await wait(() => getByText('Sign Out'));
+    describe('when the user clicks the sign in button', () => {
+      it('allows the user to sign in', () => {
+        jest.useFakeTimers();
+        const { getByText } = render(<HomeScreen />);
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        fireEvent.press(getByText('Sign In With Google'));
+
+        act(() => {
+          jest.runAllTimers();
+        });
+
+        expect(SignInWithGoogleAsync).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/modules/navigation/test/components/routes-test.js
+++ b/modules/navigation/test/components/routes-test.js
@@ -1,5 +1,10 @@
 import Routes from '@navigation/src/components/routes';
 
+jest.mock('@auth/src/google-auth', () => ({
+  SignInWithGoogleAsync: () => Promise.resolve({}),
+  SignOutWithGoogleAsync: () => Promise.resolve({}),
+}));
+
 describe('Routes', () => {
   it('should return an object of routes mapped to something which can be rendered', () => {
     Object.keys(Routes).forEach((routeName) => {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@emotion/core": "^10.0.14",
     "babel-plugin-module-resolver": "^3.2.0",
     "expo": "^33.0.0",
+    "expo-secure-store": "~5.0.1",
     "react": "16.8.3",
     "react-dom": "^16.8.6",
     "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",


### PR DESCRIPTION
Implements the google login functionality, storing the access token for the user into `expo-secure-store`. 

More configuration will be needed for this to work on real devices, but the current implementation works great on the expo client. 

Starting to really feel the pain of native modules and writing tests around them - might need to do some more research into established projects on how they handle the jest mock hoisting