### PR TITLE
implemented google drive access, based on drive folder url

### DIFF
--- a/modules/auth/src/google-auth.js
+++ b/modules/auth/src/google-auth.js
@@ -6,7 +6,7 @@ const config = {
   androidClientId: '187519984491-jlj13hshd2alq5krd1ql08gh87lq0eq2.apps.googleusercontent.com',
   // iosStandaloneAppClientId: '<YOUR_IOS_CLIENT_ID>',
   // androidStandaloneAppClientId: '<YOUR_ANDROID_CLIENT_ID>',
-  scopes: ['profile'],
+  scopes: ['profile', 'https://www.googleapis.com/auth/drive.readonly'],
 };
 
 export async function SignInWithGoogleAsync() {

--- a/modules/core/src/models/song.js
+++ b/modules/core/src/models/song.js
@@ -1,13 +1,11 @@
 export default class Song {
-  constructor({ googleDriveUrl }) {
-    this.googleDriveUrl = googleDriveUrl;
-    this.songName = this._determineSongName({
-      googleDriveUrl,
-    });
-    this.songLength = 120;
-  }
-
-  _determineSongName({ googleDriveUrl }) {
-    return googleDriveUrl;
+  constructor({
+    googleDriveId, songName, localDownloadUri,
+  }) {
+    this.googleDriveId = googleDriveId;
+    this.googleDriveUrl = `https://www.googleapis.com/drive/v3/files/${googleDriveId}?alt=media?fields=fileExtension%2CfullFileExtension`;
+    this.songName = songName;
+    this.localDownloadUri = localDownloadUri;
+    this.songLength = null;
   }
 }

--- a/modules/home/src/scenes/home-screen.js
+++ b/modules/home/src/scenes/home-screen.js
@@ -29,8 +29,8 @@ function HomeScreen({ navigation }) {
   };
 
   const continueToSongSelection = () => {
-    const songs = RandomSongList(6);
-
+    // const songs = RandomSongList(6);
+    const songs = [];
     navigation.navigate('SongSelection', {
       songs,
     });

--- a/modules/song-selection/src/api/google-drive-access.js
+++ b/modules/song-selection/src/api/google-drive-access.js
@@ -1,0 +1,73 @@
+import Song from '@core/src/models/song';
+import { documentDirectory, downloadAsync, getInfoAsync } from 'expo-file-system';
+import { getItemAsync } from 'expo-secure-store';
+
+export async function GetSongs(googleDriveURL) {
+  const songFolderId = getQueryVariable({
+    variable: 'id',
+    url: googleDriveURL,
+  });
+
+  const accessToken = await getItemAsync('google-access-token');
+  if (accessToken) {
+    try {
+      const songs = await getSongMetadata(songFolderId, accessToken);
+      await downloadSongs(songs, accessToken);
+      return Promise.resolve(songs);
+    } catch (err) {
+      throw new Error('error downloading songs from google drive!', err);
+    }
+  } else {
+    throw new Error('cant communicate with Google Drive if not logged in!');
+  }
+}
+
+const getSongMetadata = async (songFolderId, accessToken) => {
+  const options = configureGetOptions(accessToken);
+  const response = await fetch(`https://www.googleapis.com/drive/v3/files?q='${songFolderId}'+in+parents`, options);
+
+  if (response.status === 200) {
+    const data = await response.json();
+    const songs = data.files.filter((songMeta) => songMeta.mimeType.startsWith('audio/')).map((songMeta) => {
+      return new Song({
+        songName: songMeta.name,
+        googleDriveId: songMeta.id,
+        localDownloadUri: `${documentDirectory}${songMeta.id}`,
+      });
+    });
+    return Promise.resolve(songs);
+  }
+};
+
+const downloadSongs = async (songs, accessToken) => {
+  const options = configureGetOptions(accessToken);
+  songs.forEach(async (song) => {
+    if (song.localDownloadUri) {
+      const existingFileData = await getInfoAsync(song.localDownloadUri);
+      if (existingFileData.exists && existingFileData.size > 0) {
+        return;
+      }
+    }
+    await downloadAsync(song.googleDriveUrl, song.localDownloadUri, options);
+  });
+};
+
+const getQueryVariable = ({ variable, url }) => {
+  const splitString = url.split('?');
+  const paramString = splitString[1];
+  const vars = paramString?.split('&');
+  for (let i = 0; i < vars.length; i++) {
+    const pair = vars[i].split('=');
+    if (pair[0] === variable) { return pair[1]; }
+  }
+  return false;
+};
+
+const configureGetOptions = (accessToken) => {
+  const headers = new Headers();
+  headers.append('Authorization', `Bearer ${accessToken}`);
+  return {
+    method: 'GET',
+    headers,
+  };
+};

--- a/modules/song-selection/src/scenes/song-selection.js
+++ b/modules/song-selection/src/scenes/song-selection.js
@@ -1,20 +1,46 @@
 import Colors from '@theme/src/utils/colors';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
+import RehearseButton from '@core/src/components/rehearse-button';
 import RehearseText from '@core/src/components/rehearse-text';
 import SafeAreaView from '@core/src/components/safe-area-view';
 import Song from '@core/src/models/song';
 import SongSelectionButton from '@song-selection/src/components/song-selection-button';
 import Theme from '@theme/src/utils/theme';
+import { GetSongs } from '@song-selection/src/api/google-drive-access';
 import { StyleSheet, View } from 'react-native';
+import { deleteItemAsync, getItemAsync, setItemAsync } from 'expo-secure-store';
 import { withMappedNavigationParams } from 'react-navigation-props-mapper';
 
 function SongSelection({ songs }) {
+  const [songList, setSongList] = useState(songs);
+  const [downloadingSongs, setDownloadingSongs] = useState(false);
+  const [driveUrl, setDriveUrl] = useState('https://drive.google.com/open?id=1wYdxpc_4-VJDuXiQSU4_NPVKoVqlTUtU');
+
+  const handleGetSongs = async () => {
+    setDownloadingSongs(true);
+    const downloadedSongs = await GetSongs(driveUrl);
+    setSongList(downloadedSongs);
+    setDownloadingSongs(false);
+  };
+
   return (
     <SafeAreaView style={styles.sceneContainer}>
       <View style={styles.songListContainer}>
         <RehearseText style={styles.selectSongTitle}>Select Song</RehearseText>
-        {songs.map((song, i) => {
+        <RehearseText>Current Drive Url:</RehearseText>
+        <RehearseText>{driveUrl}</RehearseText>
+        <RehearseButton
+          onPress={() => handleGetSongs()}
+          style={styles.getSongsButton}
+        ><RehearseText>Attempt to get songs!</RehearseText>
+        </RehearseButton>
+        <RehearseButton
+          onPress={() => deleteItemAsync('google-access-token')}
+          style={styles.getSongsButton}
+        ><RehearseText>Log out of google</RehearseText>
+        </RehearseButton>
+        {songList.map((song, i) => {
           return (
             <SongSelectionButton
               key={i}
@@ -24,6 +50,9 @@ function SongSelection({ songs }) {
               style={styles.songSelectButton}
             />);
         })}
+        {downloadingSongs &&
+          <RehearseText>Downloading...</RehearseText>
+        }
       </View>
     </SafeAreaView>
   );
@@ -46,6 +75,14 @@ const styles = StyleSheet.create({
   },
   songSelectButton: {
     margin: 10,
+  },
+  getSongsButton: {
+    margin: 10,
+    position: 'relative',
+    backgroundColor: Colors.secondaryLight(),
+    borderRadius: 20,
+    padding: 10,
+    width: '90%',
   },
 });
 

--- a/modules/song-selection/test/api/google-drive-access-test.js
+++ b/modules/song-selection/test/api/google-drive-access-test.js
@@ -1,0 +1,48 @@
+import * as ExpoFileSystem from 'expo-file-system';
+import * as ExpoSecureStore from 'expo-secure-store';
+import * as ReactNative from 'react-native';
+import Song from '@core/src/models/song';
+import { GetSongs } from '@song-selection/src/api/google-drive-access';
+import { fetchMock } from 'fetch-mock';
+
+describe('GetSongs', () => {
+  describe('when all is well, happy path', () => {
+    let downloadAsyncCalled;
+    beforeEach(() => {
+      downloadAsyncCalled = false;
+      ReactNative.Headers = () => {};
+      ExpoSecureStore.getItemAsync = () => 'some_access_token';
+      ExpoFileSystem.getInfoAsync = () => {
+        return {
+          exists: false,
+        };
+      };
+      ExpoFileSystem.downloadAsync = () => {
+        downloadAsyncCalled = true;
+      };
+      ExpoFileSystem.documentDirectory = 'someDirectory/';
+      fetchMock.getOnce('https://www.googleapis.com/drive/v3/files', Promise.resolve({
+        status: 200,
+        data: {
+          files: [
+            {
+              name: 'some-song-name-1',
+              id: 'some-song-id-1',
+              mimeType: 'audio/x-wav',
+            },
+          ],
+        },
+      }));
+    });
+
+    it('downloads all the audio files in the google drive and returns the songs', async () => {
+      const result = await GetSongs('https://drive.google.com/open?id=some-drive-id');
+      expect(downloadAsyncCalled).toEqual(true);
+      expect(result.length).toEqual(1);
+      expect(result[0]).toBeInstanceOf(Song);
+      expect(result[0].name).toEqual('some-song-name-1');
+      expect(result[0].id).toEqual('some-song-id-1');
+      expect(result[0].localDownloadUri).toEqual('someDirectory/some-song-id-1');
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@emotion/core": "^10.0.14",
     "babel-plugin-module-resolver": "^3.2.0",
     "expo": "^33.0.0",
+    "expo-file-system": "~5.0.1",
     "expo-secure-store": "~5.0.1",
     "react": "16.8.3",
     "react-dom": "^16.8.6",
@@ -41,6 +42,7 @@
     "eslint-plugin-react": "^7.14.2",
     "eslint-plugin-react-hooks": "^1.6.1",
     "eslint-plugin-root": "https://github.com/Root-App/root-eslint-plugin#97e5ae704c48e84303bab2cc001cb04fc578f374",
+    "fetch-mock": "^7.3.6",
     "jest-expo": "^33.0.2",
     "react-native-storybook-loader": "^1.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2048,6 +2048,15 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-expo@^5.0.0, babel-preset-expo@^5.1.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-expo/-/babel-preset-expo-5.2.0.tgz#37f466e65c29ab518d91d04c299d84cef07590d2"
@@ -2102,7 +2111,7 @@ babel-preset-jest@^24.6.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^24.6.0"
 
-babel-runtime@^6.11.6, babel-runtime@^6.18.0:
+babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -2659,7 +2668,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.2.2, core-js@^2.4.0, core-js@^2.4.1:
+core-js@^2.2.2, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0, core-js@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -4065,6 +4074,17 @@ fbjs@^1.0.0:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
+fetch-mock@^7.3.6:
+  version "7.3.6"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-7.3.6.tgz#81c002bfbf11db185e14d20221541bf90560269e"
+  integrity sha512-o/TgQDn9IVdZlpZcQCg/JytEh+fliDQGiF9HSVDj161OJ3dnrLvHomD4F3gDcqXuDePlRYQ2iz0gtEQ/oG3Wfg==
+  dependencies:
+    babel-polyfill "^6.26.0"
+    core-js "^2.6.9"
+    glob-to-regexp "^0.4.0"
+    path-to-regexp "^2.2.1"
+    whatwg-url "^6.5.0"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -4371,6 +4391,11 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob-to-regexp@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
@@ -6929,6 +6954,11 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-to-regexp@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
+
 path-type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
@@ -7810,6 +7840,11 @@ regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
   integrity sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+  integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -9150,7 +9185,7 @@ whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
 
-whatwg-url@^6.4.1:
+whatwg-url@^6.4.1, whatwg-url@^6.5.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
   integrity sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==


### PR DESCRIPTION
This PR implements the wrapper around the google api which allows us to pass in a google drive folder URL and download all the audio files from that folder. The audio files are saved locally to the device; however, there is currently no way to know which songs have been downloaded to the device since I'm not storing that data anyway.

Test is currently broken because i haven't figured out how to mock `new Headers()` - a dumb issue to be having :( 

Note that this pull requests ups the requirements for your google authentication to include google drive, so it may be necessary to log out and back in again.